### PR TITLE
fix: set correct config for caching and npm install

### DIFF
--- a/.github/workflows/firebase.function.publish.yml
+++ b/.github/workflows/firebase.function.publish.yml
@@ -28,13 +28,16 @@ jobs:
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
       - name: 'Install firebase-tools'
         run: npm install -g firebase-tools
       - name: 'Install npm packages'
         run: |
           cd ${{ inputs.function_path }}/functions
-          npm install
+          npm ci
       - name: 'Lint & build'
         run: |
           cd ${{ inputs.function_path }}
           firebase deploy --only functions
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: '${{ github.workspace }}/${{ vars.GOOGLE_APPLICATION_CREDENTIALS }}'


### PR DESCRIPTION
Set proper `cache-dependency-path`, run `npm ci` instead of `npm install` and add missing env `GOOGLE_APPLICATION_CREDENTIALS`