### PR TITLE
feat(ruby-version): Add an input for Ruber vesion

### DIFF
--- a/.github/workflows/flutter.publish.yml
+++ b/.github/workflows/flutter.publish.yml
@@ -9,6 +9,10 @@ on:
       url:
         description: 'Set the Playstore URL of the app'
         type: string
+      ruby_version:
+        description: 'The Ruby version used for Fastlane (ex: 3.4.10)'
+        required: true
+        type: string
 jobs:
   play_store:
     environment:
@@ -34,7 +38,7 @@ jobs:
       - name: 'Setup Ruby'
         uses: ruby/setup-ruby@v1.312.0
         with:
-          ruby-version: '3.4.10'
+          ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
         env:
           BUNDLE_GEMFILE: 'android/Gemfile'


### PR DESCRIPTION
Add a nez input for the Ruby version: `ruby_version` into the flutter.publish.yml workflow

This change to prevent errors like this : https://github.com/vareversat/chabo-app/actions/runs/29206748976/job/86688237829